### PR TITLE
Fix logistic regression training split

### DIFF
--- a/Capstone_LogisticRegression.py
+++ b/Capstone_LogisticRegression.py
@@ -114,7 +114,7 @@ clean_data.show()
 # %%
 (training,testing) = clean_data.randomSplit([0.7,0.3])
 logr = LogisticRegression(featuresCol='features', labelCol='label')
-logr_model = logr.fit(clean_data)
+logr_model = logr.fit(training)
 
 # %% [markdown]
 # ## Prediction on training data


### PR DESCRIPTION
## Summary
- fix logistic regression to fit only on the training split

## Testing
- `python -m py_compile Capstone_LogisticRegression.py`

------
https://chatgpt.com/codex/tasks/task_e_683f762a4f8c8324b2edc16e114f6bc3