### PR TITLE
Fix training split for SVM model

### DIFF
--- a/Capstone_SVM.py
+++ b/Capstone_SVM.py
@@ -113,7 +113,7 @@ clean_data.show()
 # %%
 (training,testing) = clean_data.randomSplit([0.7,0.3])
 svc = LinearSVC(featuresCol='features', labelCol='label')
-svc_model = svc.fit(clean_data)
+svc_model = svc.fit(training)
 
 # %% [markdown]
 # ## Prediction on training data


### PR DESCRIPTION
## Summary
- train the Linear SVC only on the training split

## Testing
- `python -m py_compile Capstone_SVM.py`


------
https://chatgpt.com/codex/tasks/task_e_683f7a6eefc88324b5cf88937897d736