### PR TITLE
Fix typo in Capstone_EDA

### DIFF
--- a/Capstone_EDA.ipynb
+++ b/Capstone_EDA.ipynb
@@ -184,7 +184,7 @@
     }
    ],
    "source": [
-    "#Computing the new column sentinment on basis of rating \n",
+    "#Computing the new column sentiment on basis of rating \n",
     "def sentiment(x):\n",
     "    if x>5:\n",
     "        return 1\n",

--- a/Capstone_EDA.py
+++ b/Capstone_EDA.py
@@ -40,7 +40,7 @@ df_train.head()
 
 
 # %%
-#Computing the new column sentinment on basis of rating 
+#Computing the new column sentiment on basis of rating
 def sentiment(x):
     if x>5:
         return 1


### PR DESCRIPTION
## Summary
- correct typo 'sentinment' -> 'sentiment' in Capstone_EDA.py
- adjust the same comment inside the Jupyter notebook

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f7a6e53c08324962690ff93c39207